### PR TITLE
14 fix

### DIFF
--- a/ENABLE_MULTI_WORKSPACE_STEP_BY_STEP.md
+++ b/ENABLE_MULTI_WORKSPACE_STEP_BY_STEP.md
@@ -30,7 +30,7 @@ DEFAULT_SUBDOMAIN=app
 NODE_ENV=development
 PG_DATABASE_URL=postgres://postgres:postgres@localhost:5432/default
 REDIS_URL=redis://localhost:6379
-APP_SECRET=mk+mc0YBcVlj4HParyCmdA+2VP0q/7PRqupMAYCFhu0=
+APP_SECRET=<replace_with_random_32_characters>
 SIGN_IN_PREFILLED=true
 
 FRONTEND_URL=http://localhost:3001

--- a/packages/twenty-front/src/modules/object-record/hooks/useCreateOneRecord.ts
+++ b/packages/twenty-front/src/modules/object-record/hooks/useCreateOneRecord.ts
@@ -83,7 +83,7 @@ export const useCreateOneRecord = <
 
     const idForCreation = recordInput.id ?? v4();
 
-    const sanitizedInput = {
+    const sanitizedRecordInput = {
       ...sanitizeRecordInput({
         objectMetadataItem,
         recordInput,
@@ -98,8 +98,7 @@ export const useCreateOneRecord = <
       objectMetadataItems,
       recordInput: {
         ...computeOptimisticCreateRecordBaseRecordInput(objectMetadataItem),
-        ...recordInput,
-        id: idForCreation,
+        ...sanitizedRecordInput,
       },
       objectPermissionsByObjectMetadataId,
     });
@@ -138,7 +137,7 @@ export const useCreateOneRecord = <
       .mutate({
         mutation: createOneRecordMutation,
         variables: {
-          input: sanitizedInput,
+          input: sanitizedRecordInput,
         },
         update: (cache, { data }) => {
           const record = data?.[mutationResponseField];

--- a/packages/twenty-server/src/engine/metadata-modules/field-metadata/types/composite-field-metadata-type.type.ts
+++ b/packages/twenty-server/src/engine/metadata-modules/field-metadata/types/composite-field-metadata-type.type.ts
@@ -9,6 +9,8 @@ const compositeFieldTypes = [
   FieldMetadataType.PHONES,
   FieldMetadataType.RICH_TEXT_V2,
   FieldMetadataType.ACTOR,
+  FieldMetadataType.PDF,
+  FieldMetadataType.IMAGE,
 ] as const;
 
 export type CompositeFieldMetadataType = (typeof compositeFieldTypes)[number];

--- a/packages/twenty-shared/src/types/composite-types/composite-type-definitions.ts
+++ b/packages/twenty-shared/src/types/composite-types/composite-type-definitions.ts
@@ -5,7 +5,9 @@ import { addressCompositeType } from './address.composite-type';
 import { currencyCompositeType } from './currency.composite-type';
 import { emailsCompositeType } from './emails.composite-type';
 import { fullNameCompositeType } from './full-name.composite-type';
+import { imageCompositeType } from './image.composite-type';
 import { linksCompositeType } from './links.composite-type';
+import { pdfCompositeType } from './pdf.composite-type';
 import { phonesCompositeType } from './phones.composite-type';
 import { richTextV2CompositeType } from './rich-text-v2.composite-type';
 
@@ -21,4 +23,6 @@ export const compositeTypeDefinitions = new Map<
   [FieldMetadataType.EMAILS, emailsCompositeType],
   [FieldMetadataType.PHONES, phonesCompositeType],
   [FieldMetadataType.RICH_TEXT_V2, richTextV2CompositeType],
+  [FieldMetadataType.PDF, pdfCompositeType],
+  [FieldMetadataType.IMAGE, imageCompositeType],
 ]);


### PR DESCRIPTION
## Summary by Sourcery

Register new composite field types PDF and IMAGE, improve variable naming in the create record hook, and update documentation to prompt for a customizable APP_SECRET

New Features:
- Add PDF and IMAGE as supported composite field types in metadata and shared definitions

Enhancements:
- Rename sanitizedInput to sanitizedRecordInput in the useCreateOneRecord hook for clarity

Documentation:
- Update the multi-workspace setup guide to use a placeholder for APP_SECRET instead of a fixed value